### PR TITLE
Fix exporting to a relative target directory.

### DIFF
--- a/databroker_pack/_pack.py
+++ b/databroker_pack/_pack.py
@@ -409,6 +409,7 @@ def write_documents_manifest(manager, directory, artifacts):
     artifacts: List[Str]
     """
     FILENAME = "documents_manifest.txt"
+    abs_directory = pathlib.Path(directory).absolute()
     with manager.open("documents_manifest", FILENAME, "xt") as file:
         for artifact in artifacts:
-            file.write(f"{pathlib.Path(artifact).relative_to(directory)!s}\n")
+            file.write(f"{pathlib.Path(artifact).relative_to(abs_directory)!s}\n")

--- a/databroker_pack/tests/test_cli.py
+++ b/databroker_pack/tests/test_cli.py
@@ -1,3 +1,4 @@
+import pathlib
 import subprocess
 import sys
 
@@ -41,18 +42,29 @@ import pytest
         ],
     ],
 )
-def test_pack_smoke(cli_args, simple_catalog, tmpdir):
+@pytest.mark.parametrize(
+    "relative_target_directory", [True, False])
+def test_pack_smoke(cli_args, simple_catalog, tmpdir, relative_target_directory):
     "Smoke test common options."
     TIMEOUT = 10
-    DIRECTORY = tmpdir
     CATALOG = simple_catalog
-    p = subprocess.Popen(
-        [sys.executable, "-um", "databroker_pack.commandline.pack"]
-        + [CATALOG, DIRECTORY]
-        + cli_args,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
+    if relative_target_directory:
+        p = subprocess.Popen(
+            [sys.executable, "-um", "databroker_pack.commandline.pack"]
+            + [CATALOG, pathlib.Path(tmpdir).parts[-1]]
+            + cli_args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=str(pathlib.Path(tmpdir).parent)
+        )
+    else:
+        p = subprocess.Popen(
+            [sys.executable, "-um", "databroker_pack.commandline.pack"]
+            + [CATALOG, tmpdir]
+            + cli_args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
     # Capture stdout, stderr for interactive debugging.
     stdout, stderr = p.communicate(TIMEOUT)
     assert p.returncode == 0

--- a/databroker_pack/tests/test_cli.py
+++ b/databroker_pack/tests/test_cli.py
@@ -42,8 +42,7 @@ import pytest
         ],
     ],
 )
-@pytest.mark.parametrize(
-    "relative_target_directory", [True, False])
+@pytest.mark.parametrize("relative_target_directory", [True, False])
 def test_pack_smoke(cli_args, simple_catalog, tmpdir, relative_target_directory):
     "Smoke test common options."
     TIMEOUT = 10
@@ -55,7 +54,7 @@ def test_pack_smoke(cli_args, simple_catalog, tmpdir, relative_target_directory)
             + cli_args,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            cwd=str(pathlib.Path(tmpdir).parent)
+            cwd=str(pathlib.Path(tmpdir).parent),
         )
     else:
         p = subprocess.Popen(


### PR DESCRIPTION
This fixes the bug we encountered in the group exercise.

The tests only covered the usage

```
databroker-pack ... /path/to/directory  # <-- absolute path
```

not

```
databroker-pack ... path/to/directory  # <-- relative to cwd
```

The tests now cover both and fix the issue.