### PR TITLE
Place msgpack/jsonl in a subdirectory.

### DIFF
--- a/databroker_pack/_pack.py
+++ b/databroker_pack/_pack.py
@@ -234,7 +234,9 @@ def export_run(
     with event_model.Filler(
         handler_registry, inplace=False, root_map=root_map
     ) as filler:
-        with serializer_class(directory) as serializer:
+        with serializer_class(
+            directory, file_prefix="documents/{start[uid]}"
+        ) as serializer:
             with tqdm(position=0) as progress:
                 for name, doc in run.canonical(fill="no"):
                     if name == "resource":

--- a/databroker_pack/commandline/pack.py
+++ b/databroker_pack/commandline/pack.py
@@ -339,10 +339,10 @@ $ databroker-pack CATALOG --all --copy-external DIRECTORY
                     root_map.update({root: root})
                     write_external_files_manifest(manager, root, files)
         if args.format == "jsonl":
-            paths = ["./*.jsonl"]
+            paths = ["./documents/*.jsonl"]
             write_jsonl_catalog_file(manager, args.directory, paths, root_map)
         elif args.format == "msgpack":
-            paths = ["./*.msgpack"]
+            paths = ["./documents/*.msgpack"]
             write_msgpack_catalog_file(manager, args.directory, paths, root_map)
         # No need for an else here; we validated that it is one of these above.
         if failures:

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -27,7 +27,8 @@ techniques, and instruments.
 That said, it is sometimes necessary to take a look under the hood. The pack
 directory always contains:
 
-* Either msgpack (binary) or JSONL (plaintext) files containing the Bluesky
+* A directory named ``documents`` containing either msgpack (binary) or JSONL
+  (plaintext) files containing the Bluesky
   `Documents <https://blueskyproject.io/event-model/data-model.html>`_.
 * Text manifests listing the names of these files relative to the directory
   root. The manifests maybe split over multiple files named like


### PR DESCRIPTION
When the number of runs becomes large it difficult to dig through all the `*.msgpack` files or `*.jsonl` files to find the manifests or the `external_files` directory. This moves them into a `documents/` subdirectory.