### PR TITLE
TST/BLD: add test data to package data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,3 +14,5 @@ include databroker_pack/_version.py
 
 # If including data files in the package, add them like:
 # include path/to/data_file
+
+include databroker_pack/tests/data

--- a/databroker_pack/tests/conftest.py
+++ b/databroker_pack/tests/conftest.py
@@ -1,19 +1,20 @@
 import os
-import pathlib
+from pathlib import PurePath
+from pkg_resources import resource_filename
 
 import databroker
 import pytest
 
-from .. import unpack_inplace
+from databroker_pack._unpack import unpack_inplace
 
-DATA_DIR = pathlib.Path(__file__).parent / "data"
+DATA_DIR = PurePath(resource_filename('databroker_pack', 'tests/data'))
 
 
 @pytest.fixture(scope="module")
 def simple_catalog():
     DIRECTORY = "simple_catalog"
     NAME = "databroker_pack_tests_simple_catalog"
-    config_path = unpack_inplace(DATA_DIR / DIRECTORY, NAME)
+    config_path = unpack_inplace(str(DATA_DIR.joinpath(DIRECTORY)), NAME)
     try:
         # Use this once list_configs() is fixed to be complete.
         # It is incomplete in databroker 1.0.0.

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
     include_package_data=True,
     package_data={
         "databroker_pack": [
+            'tests/data'
             # When adding files here, remember to update MANIFEST.in as well,
             # or else they will not be included in the distribution on PyPI!
             # 'path/to/data_file',


### PR DESCRIPTION
Hi @tacaswell . I add the tests/data into the package data and use pkg_resource to use it in the conftest.

I didn't run the test to check because I encountered trouble when installing the databroker from the pypi and source (I tried both of them and encountered the same error). I will submit issue in databroker repo for this.