### PR TITLE
return file uids

### DIFF
--- a/databroker_pack/_pack.py
+++ b/databroker_pack/_pack.py
@@ -96,6 +96,7 @@ def export_uids(
       Resource documents, keyed on ``(root_in_document, root, unique_id)``.
     * ``failures`` is a list of uids of runs that raised Exceptions. (The
       relevant tracebacks are logged.)
+    * ``file_uids`` is a dictionary of filenames mapped to a list of RunStart unique IDs.
     """
     accumulated_files = collections.defaultdict(set)
     file_uids = collection.defaultdict(list)
@@ -202,6 +203,7 @@ def export_catalog(
       Resource documents, keyed on ``(root_in_document, root, unique_id)``.
     * ``failures`` is a list of uids of runs that raised Exceptions. (The
       relevant tracebacks are logged.)
+    * ``file_uids`` is a dictionary of filenames mapped to a list of RunStart unique IDs.
     """
     if limit is not None:
         if limit < 1:

--- a/databroker_pack/_pack.py
+++ b/databroker_pack/_pack.py
@@ -98,6 +98,7 @@ def export_uids(
       relevant tracebacks are logged.)
     """
     accumulated_files = collections.defaultdict(set)
+    file_uids = collection.defaultdict(list)
     accumulated_artifacts = collections.defaultdict(set)
     failures = []
     if salt is None:
@@ -119,6 +120,8 @@ def export_uids(
                 )
                 for root, set_ in files.items():
                     accumulated_files[root].update(set_)
+                    for filename in set_:
+                        file_uids[filename].append[uid]
                 for name, list_ in artifacts.items():
                     accumulated_artifacts[name].update(list_)
 
@@ -131,7 +134,7 @@ def export_uids(
                     f"Writing Documents ({len(failures)} failures)", refresh=False
                 )
             progress.update()
-    return dict(accumulated_artifacts), dict(accumulated_files), failures
+    return dict(accumulated_artifacts), dict(accumulated_files), failures, dict(file_uids)
 
 
 def export_catalog(
@@ -205,7 +208,9 @@ def export_catalog(
             raise ValueError("limit must be None or a number 1 or greater")
         limit = int(limit)
     accumulated_files = collections.defaultdict(set)
+    file_uids = collection.defaultdict(list)
     accumulated_artifacts = collections.defaultdict(set)
+    file_uid = {}
     failures = []
     if salt is None:
         salt = secrets.token_hex(32).encode()
@@ -229,6 +234,8 @@ def export_catalog(
                 )
                 for root, set_ in files.items():
                     accumulated_files[root].update(set_)
+                    for filename in set_:
+                        file_uids[filename].append[uid]
                 for name, list_ in artifacts.items():
                     accumulated_artifacts[name].update(list_)
             except Exception:
@@ -240,7 +247,7 @@ def export_catalog(
                     f"Writing Documents ({len(failures)} failures)", refresh=False
                 )
             progress.update()
-    return dict(accumulated_artifacts), dict(accumulated_files), failures
+    return dict(accumulated_artifacts), dict(accumulated_files), failures, dict(file_uids)
 
 
 def export_run(

--- a/databroker_pack/_pack.py
+++ b/databroker_pack/_pack.py
@@ -120,9 +120,10 @@ def export_uids(
                     root_map=source_catalog.root_map,
                     serializer_class=serializer_class,
                 )
+                file_uids[uid] = []
                 for root, set_ in files.items():
                     accumulated_files[root].update(set_)
-                    file_uids[uid] = [(root, filename) for filename in set_]
+                    file_uids[uid].extend([(root, filename) for filename in set_])
                 for name, list_ in artifacts.items():
                     accumulated_artifacts[name].update(list_)
 
@@ -234,9 +235,10 @@ def export_catalog(
                     root_map=source_catalog.root_map,
                     serializer_class=serializer_class,
                 )
+                file_uids[uid] = []
                 for root, set_ in files.items():
                     accumulated_files[root].update(set_)
-                    file_uids[uid] = [(root, filename) for filename in set_]
+                    file_uids[uid].extend([(root, filename) for filename in set_])
                 for name, list_ in artifacts.items():
                     accumulated_artifacts[name].update(list_)
             except Exception:

--- a/databroker_pack/_pack.py
+++ b/databroker_pack/_pack.py
@@ -96,7 +96,8 @@ def export_uids(
       Resource documents, keyed on ``(root_in_document, root, unique_id)``.
     * ``failures`` is a list of uids of runs that raised Exceptions. (The
       relevant tracebacks are logged.)
-    * ``file_uids`` is a dictionary of filenames mapped to a list of RunStart unique IDs.
+    * ``file_uids`` is a dictionary of RunStart unique IDs mapped to
+      ``(root, filename)``.
     """
     accumulated_files = collections.defaultdict(set)
     file_uids = collections.defaultdict(list)
@@ -122,7 +123,7 @@ def export_uids(
                 for root, set_ in files.items():
                     accumulated_files[root].update(set_)
                     for filename in set_:
-                        file_uids[filename].append[uid]
+                        file_uids[uid].append[(root, filename)]
                 for name, list_ in artifacts.items():
                     accumulated_artifacts[name].update(list_)
 
@@ -203,7 +204,8 @@ def export_catalog(
       Resource documents, keyed on ``(root_in_document, root, unique_id)``.
     * ``failures`` is a list of uids of runs that raised Exceptions. (The
       relevant tracebacks are logged.)
-    * ``file_uids`` is a dictionary of filenames mapped to a list of RunStart unique IDs.
+    * ``file_uids`` is a dictionary of RunStart unique IDs mapped to
+      ``(root, filename)``.
     """
     if limit is not None:
         if limit < 1:
@@ -237,7 +239,7 @@ def export_catalog(
                 for root, set_ in files.items():
                     accumulated_files[root].update(set_)
                     for filename in set_:
-                        file_uids[filename].append[uid]
+                        file_uids[uid].append[(root, filename)]
                 for name, list_ in artifacts.items():
                     accumulated_artifacts[name].update(list_)
             except Exception:

--- a/databroker_pack/_pack.py
+++ b/databroker_pack/_pack.py
@@ -100,7 +100,7 @@ def export_uids(
       ``(root, filename)``.
     """
     accumulated_files = collections.defaultdict(set)
-    file_uids = collections.defaultdict(list)
+    file_uids = {}
     accumulated_artifacts = collections.defaultdict(set)
     failures = []
     if salt is None:
@@ -122,8 +122,7 @@ def export_uids(
                 )
                 for root, set_ in files.items():
                     accumulated_files[root].update(set_)
-                    for filename in set_:
-                        file_uids[uid].append((root, filename))
+                    file_uids[uid] = [(root, filename) for filename in set_]
                 for name, list_ in artifacts.items():
                     accumulated_artifacts[name].update(list_)
 
@@ -136,7 +135,7 @@ def export_uids(
                     f"Writing Documents ({len(failures)} failures)", refresh=False
                 )
             progress.update()
-    return dict(accumulated_artifacts), dict(accumulated_files), failures, dict(file_uids)
+    return dict(accumulated_artifacts), dict(accumulated_files), failures, file_uids
 
 
 def export_catalog(
@@ -212,7 +211,7 @@ def export_catalog(
             raise ValueError("limit must be None or a number 1 or greater")
         limit = int(limit)
     accumulated_files = collections.defaultdict(set)
-    file_uids = collections.defaultdict(list)
+    file_uids = {}
     accumulated_artifacts = collections.defaultdict(set)
     failures = []
     if salt is None:
@@ -237,8 +236,7 @@ def export_catalog(
                 )
                 for root, set_ in files.items():
                     accumulated_files[root].update(set_)
-                    for filename in set_:
-                        file_uids[uid].append((root, filename))
+                    file_uids[uid] = [(root, filename) for filename in set_]
                 for name, list_ in artifacts.items():
                     accumulated_artifacts[name].update(list_)
             except Exception:
@@ -250,7 +248,7 @@ def export_catalog(
                     f"Writing Documents ({len(failures)} failures)", refresh=False
                 )
             progress.update()
-    return dict(accumulated_artifacts), dict(accumulated_files), failures, dict(file_uids)
+    return dict(accumulated_artifacts), dict(accumulated_files), failures, file_uids
 
 
 def export_run(

--- a/databroker_pack/_pack.py
+++ b/databroker_pack/_pack.py
@@ -99,7 +99,7 @@ def export_uids(
     * ``file_uids`` is a dictionary of filenames mapped to a list of RunStart unique IDs.
     """
     accumulated_files = collections.defaultdict(set)
-    file_uids = collection.defaultdict(list)
+    file_uids = collections.defaultdict(list)
     accumulated_artifacts = collections.defaultdict(set)
     failures = []
     if salt is None:
@@ -210,7 +210,7 @@ def export_catalog(
             raise ValueError("limit must be None or a number 1 or greater")
         limit = int(limit)
     accumulated_files = collections.defaultdict(set)
-    file_uids = collection.defaultdict(list)
+    file_uids = collections.defaultdict(list)
     accumulated_artifacts = collections.defaultdict(set)
     file_uid = {}
     failures = []

--- a/databroker_pack/_pack.py
+++ b/databroker_pack/_pack.py
@@ -123,7 +123,7 @@ def export_uids(
                 file_uids[uid] = []
                 for root, set_ in files.items():
                     accumulated_files[root].update(set_)
-                    file_uids[uid].extend([(root, filename) for filename in set_])
+                    file_uids[uid].extend((root, filename) for filename in set_)
                 for name, list_ in artifacts.items():
                     accumulated_artifacts[name].update(list_)
 

--- a/databroker_pack/_pack.py
+++ b/databroker_pack/_pack.py
@@ -123,7 +123,7 @@ def export_uids(
                 for root, set_ in files.items():
                     accumulated_files[root].update(set_)
                     for filename in set_:
-                        file_uids[uid].append[(root, filename)]
+                        file_uids[uid].append((root, filename))
                 for name, list_ in artifacts.items():
                     accumulated_artifacts[name].update(list_)
 
@@ -238,7 +238,7 @@ def export_catalog(
                 for root, set_ in files.items():
                     accumulated_files[root].update(set_)
                     for filename in set_:
-                        file_uids[uid].append[(root, filename)]
+                        file_uids[uid].append((root, filename))
                 for name, list_ in artifacts.items():
                     accumulated_artifacts[name].update(list_)
             except Exception:

--- a/databroker_pack/_pack.py
+++ b/databroker_pack/_pack.py
@@ -238,7 +238,7 @@ def export_catalog(
                 file_uids[uid] = []
                 for root, set_ in files.items():
                     accumulated_files[root].update(set_)
-                    file_uids[uid].extend([(root, filename) for filename in set_])
+                    file_uids[uid].extend((root, filename) for filename in set_)
                 for name, list_ in artifacts.items():
                     accumulated_artifacts[name].update(list_)
             except Exception:

--- a/databroker_pack/_pack.py
+++ b/databroker_pack/_pack.py
@@ -214,7 +214,6 @@ def export_catalog(
     accumulated_files = collections.defaultdict(set)
     file_uids = collections.defaultdict(list)
     accumulated_artifacts = collections.defaultdict(set)
-    file_uid = {}
     failures = []
     if salt is None:
         salt = secrets.token_hex(32).encode()

--- a/databroker_pack/commandline/pack.py
+++ b/databroker_pack/commandline/pack.py
@@ -402,4 +402,4 @@ $ databroker-pack CATALOG --all --copy-external DIRECTORY
 
 
 if __name__ == "__main__":
-   main()
+    main()

--- a/databroker_pack/commandline/pack.py
+++ b/databroker_pack/commandline/pack.py
@@ -287,7 +287,7 @@ $ databroker-pack CATALOG --all --copy-external DIRECTORY
             if not results:
                 print(f"Query {combined_query} yielded no results. Exiting.")
                 sys.exit(1)
-            artifacts, external_files, failures = export_catalog(
+            artifacts, external_files, failures, file_uids = export_catalog(
                 results,
                 manager,
                 strict=args.strict,
@@ -310,7 +310,7 @@ $ databroker-pack CATALOG --all --copy-external DIRECTORY
             if not uids:
                 print("Found empty input for --uids. Exiting")
                 sys.exit(1)
-            artifacts, external_files, failures = export_uids(
+            artifacts, external_files, failures, file_uids = export_uids(
                 catalog,
                 uids[:args.limit],
                 manager,

--- a/databroker_pack/commandline/pack.py
+++ b/databroker_pack/commandline/pack.py
@@ -402,4 +402,4 @@ $ databroker-pack CATALOG --all --copy-external DIRECTORY
 
 
 if __name__ == "__main__":
-    main()
+   main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-databroker >=1.0.1
+databroker >=1.0.5
 event-model
 intake >=0.5.5
 suitcase-jsonl


### PR DESCRIPTION
Rube uses databroker-pack to get information about the files to transfer.  I am adding Rucio functionality to Rube. Rucio, in addition to transferring the files, registers the files in a database used to help manage the files.  When registering the files in Rucio I would like to associate each file with the Bluesky run_uids that reference it. This way we can query the Rucio database to tell us where the files for a specific run_uid are located.  In the future we may also want to associate each file with a proposal_id so that we can locate easily the files for a specific proposal.  

This PR updates export_catalog and export_uid to additionally return a dictionary that maps filename to a list of run_uids.